### PR TITLE
Feat: generate c-abi functions for testing

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,5 +2,10 @@
   "package": {
     "default": "openapi-forge-project",
     "description": "The crate name for the generated project."
+  },
+  "cabi": {
+    "default": "false",
+    "choices": ["false", "true"],
+    "description": "Generate C-ABI compatible functions (also used in testing.)"
   }
 }

--- a/helpers/getSome.js
+++ b/helpers/getSome.js
@@ -1,0 +1,12 @@
+const getSome = (is_cabi_str) => {
+    let some = "";
+    if (is_cabi_str == "true") {
+        some = "Option::RSome"
+    }
+    else {
+        some = "Some"
+    }
+    return some;
+}
+
+module.exports = getSome;

--- a/helpers/setPathParameters.js
+++ b/helpers/setPathParameters.js
@@ -1,8 +1,9 @@
 const Handlebars = require("handlebars");
 const toRustParamName = require("./toRustParamName");
 const getParametersByType = require("./getParametersByType");
+const getSome = require("./getSome");
 
-const setPathParameters = (path, sortedParams) => {
+const setPathParameters = (path, sortedParams, is_cabi = false) => {
   const pathParams = getParametersByType(sortedParams, "path");
   if (pathParams.length === 0) {
     return `"` +path + `"`;
@@ -37,7 +38,7 @@ const setPathParameters = (path, sortedParams) => {
             if (pathParam.required) {
               return `", &${safeParamName}.to_string(), "`;
             } else {
-              return `", &{ if let Some(${safeParamName}) = ${safeParamName} { ${safeParamName}.to_string() } else { "".to_owned() } }, "`
+              return `", &{ if let ` + getSome(is_cabi) + `(${safeParamName}) = ${safeParamName} { ${safeParamName}.to_string() } else { "".into() } }, "`
             }
           }
       }

--- a/partials/model.handlebars
+++ b/partials/model.handlebars
@@ -4,6 +4,9 @@
 */
 {{/if}}
 #[derive(Serialize, Deserialize, Debug)]
+{{#ifEquals @root.cabi "true"}}
+#[repr(C)]
+{{/ifEquals}}
 pub struct {{toClassName @key}} 
 {
   {{#each properties}}

--- a/template/Cargo.toml.handlebars
+++ b/template/Cargo.toml.handlebars
@@ -6,6 +6,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+{{#ifNotEquals _options.[generator.cabi] "true"}}
 tokio = { version = "1.27", features = ["full"] }
+{{/ifNotEquals}}
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
+{{#ifEquals _options.[generator.cabi] "true"}}
+abi_stable = "0.11"
+async-ffi = "0.4"
+
+[lib]
+crate-type = ["cdylib"]
+{{/ifEquals}}
+

--- a/template/src/api_client/api_client.rs.handlebars
+++ b/template/src/api_client/api_client.rs.handlebars
@@ -1,4 +1,11 @@
+{{setVar "cabi" _options.[generator.cabi]}}
+{{#ifEquals _options.[generator.cabi] "true"}}
+use abi_stable::std_types::RHashMap as HashMap;
+{{/ifEquals}}
+{{#ifNotEquals _options.[generator.cabi] "true"}}
 use std::collections::HashMap;
+{{/ifNotEquals}}
+
 
 use reqwest::Client;
 use reqwest::Url;
@@ -6,6 +13,17 @@ use reqwest::Url;
 use crate::config::Configuration;
 use crate::{response::ForgeResponse, model::*};
 
+{{#ifEquals _options.[generator.cabi] "true"}}
+use abi_stable::std_types::string::RString as String;
+use abi_stable::std_types::ROption as Option;
+#[allow(unused_imports)]
+use abi_stable::std_types::vec::RVec as Vec;
+use async_ffi::{FfiFuture, FutureExt};
+{{/ifEquals}}
+
+{{#ifEquals _options.[generator.cabi] "true"}}
+#[repr(C)]
+{{/ifEquals}}
 pub struct ApiClient{{_tag.name}} {
     config: Configuration,
     client: Client,
@@ -48,13 +66,13 @@ impl ApiClient{{_tag.name}} {
         {{#each _sortedParameters}}
             {{#if (hasDefault schema)}}
             // Set default value for {{toRustParamName name}}
-            let {{toRustParamName name ~}} = if ({{toRustParamName name ~}}.is_none()) { Some({{{quoteIfString schema.default}}}.to_owned()) } else { status }; 
+            let {{toRustParamName name ~}} = if ({{toRustParamName name ~}}.is_none()) { {{getSome @root.cabi}} ({{{quoteIfString schema.default}}}.into()) } else { status }; 
             {{/if ~}}
         {{/each}}
-        let url = self.config.get_base_address() + {{{setPathParameters @root.path _sortedParameters}}};
+        let url = self.config.get_base_address() + {{{setPathParameters @root.path _sortedParameters @root.cabi}}};
         let request_uri = Url::parse(&url).unwrap();
         {{#if (queryParametersExist _sortedParameters)}}
-        {{createQueryStringSnippet _sortedParameters}}
+        {{createQueryStringSnippet _sortedParameters @root.cabi}}
         {{/if}}
         let response = self.client.{{@key}}(request_uri)
         {{#if (queryParametersExist _sortedParameters)}}
@@ -69,7 +87,7 @@ impl ApiClient{{_tag.name}} {
         let headers = response
             .headers()
             .iter()
-            .map(|(k, v)| (k.to_string(), v.to_str().unwrap().to_owned()))
+            .map(|(k, v)| (k.to_string().into(), v.to_str().unwrap().into()))
             .collect::<HashMap<_, _>>();
         let data = response.json::<{{safeTypeConvert _response.schema true}}>().await.unwrap();
         ForgeResponse::new(data, status_code, headers )
@@ -93,3 +111,47 @@ impl ApiClient{{_tag.name}} {
     {{/each}}  
     {{/each}}
 }
+
+
+{{#ifEquals _options.[generator.cabi] "true"}}
+#[no_mangle]
+pub extern "C" fn c_api_client{{toRustParamName _tag.name}}_new(
+    config: Box<Configuration>,
+    client: Box<Client>,
+) -> Box<ApiClient{{_tag.name}}>{
+    Box::new(ApiClient{{_tag.name}} { config: *config, client: *client })
+}
+{{#each paths}}
+{{~setVar "path" @key}}
+{{~#each this}}
+{{~#ifEquals ../../_tag.name _tag.name}}
+{{~#if (pathContentTypeSupported this)}}
+#[no_mangle]
+pub extern "C" fn c_api_client{{toRustParamName _tag.name}}_{{toRustParamName operationId}} (
+    api_client: Box<ApiClient{{_tag.name}}>,
+    {{~#each _sortedParameters ~}}
+        {{#ifEquals required true}}
+            {{toRustParamName name ~}}: {{~safeTypeConvert schema true}},
+        {{else}}
+            {{toRustParamName name ~}}: {{~safeTypeConvert schema false}},
+        {{/ifEquals}}
+    {{~/each ~}}
+) -> FfiFuture<ForgeResponse<{{safeTypeConvert _response.schema true}}>> {
+    async move {
+        api_client.{{toRustParamName operationId}}(
+        {{~#each _sortedParameters ~}}
+            {{#ifEquals required true}}
+                {{toRustParamName name ~}},
+            {{else}}
+                {{toRustParamName name ~}},
+            {{/ifEquals}}
+        {{~/each ~}}
+        ).await
+    }
+    .into_ffi()
+}
+{{/if}}
+{{/ifEquals}}
+{{/each}}  
+{{/each}}
+{{/ifEquals}}

--- a/template/src/api_client/mod.rs.handlebars
+++ b/template/src/api_client/mod.rs.handlebars
@@ -1,3 +1,11 @@
 {{#each _tags}}
 pub mod api_client{{toRustParamName name}};
 {{/each}}
+
+{{#ifEquals _options.[generator.cabi] "true"}}
+use reqwest::Client;
+#[no_mangle]
+pub extern "C" fn c_reqwest_client_new() -> Box<Client>{
+    Box::new(Client::new())
+}
+{{/ifEquals}}

--- a/template/src/config.rs.handlebars
+++ b/template/src/config.rs.handlebars
@@ -9,7 +9,7 @@ pub struct Configuration {
 impl Configuration {
     pub fn new(base_path: &str) -> Self {
         Self {
-            base_path: base_path.to_owned(),
+            base_path: base_path.into(),
             bearer_token: None,
             selected_server_index: 0
           }
@@ -19,3 +19,11 @@ impl Configuration {
         self.base_path.to_owned() + SERVERS[self.selected_server_index]
     }
 }
+
+{{#ifEquals _options.[generator.cabi] "true"}}
+use abi_stable::std_types::string::RString;
+#[no_mangle]
+pub extern "C" fn c_config_new(base_path: RString) -> Box<Configuration>{
+    Box::new(Configuration::new(&base_path))
+}
+{{/ifEquals}}

--- a/template/src/main.rs.handlebars
+++ b/template/src/main.rs.handlebars
@@ -3,8 +3,10 @@ pub mod model;
 pub mod response;
 pub mod api_client;
 
+{{#ifEquals _options.[generator.cabi] "true"}}
+fn main() {}
+{{/ifEquals}}
+{{#ifNotEquals _options.[generator.cabi] "true"}}
 #[tokio::main]
-async pub fn main() {
-
-    
-}
+async fn main() {}
+{{/ifNotEquals}}

--- a/template/src/model.rs.handlebars
+++ b/template/src/model.rs.handlebars
@@ -1,5 +1,13 @@
 use serde::{Serialize, Deserialize};
 
+{{#ifEquals _options.[generator.cabi] "true"}}
+use abi_stable::std_types::string::RString as String;
+use abi_stable::std_types::ROption as Option;
+use abi_stable::std_types::vec::RVec as Vec;
+{{/ifEquals}}
+
+{{setVar "cabi" _options.[generator.cabi]}}
+
 {{#each components.schemas}}
 {{> model}}
 {{#unless @last}}

--- a/template/src/response.rs.handlebars
+++ b/template/src/response.rs.handlebars
@@ -1,4 +1,13 @@
+{{#ifEquals _options.[generator.cabi] "true"}}
+use abi_stable::std_types::RHashMap as HashMap;
+{{/ifEquals}}
+{{#ifNotEquals _options.[generator.cabi] "true"}}
 use std::collections::HashMap;
+{{/ifNotEquals}}
+
+{{#ifEquals _options.[generator.cabi] "true"}}
+use abi_stable::std_types::string::RString as String;
+{{/ifEquals}}
 
 use serde::{ Serialize, Deserialize };
 
@@ -6,6 +15,9 @@ use serde::{ Serialize, Deserialize };
 // Represents an HTTP response.
 // </summary>
 #[derive(Serialize, Deserialize, Debug)]
+{{#ifEquals _options.[generator.cabi] "true"}}
+#[repr(C)]
+{{/ifEquals}}
 pub struct ForgeResponse<T> {
     // <summary>
     // Gets the typed response.


### PR DESCRIPTION
This allows generating c-abi compatible functions for `api-client` functionalities (also `config` `reqwest-client` constructors) under `--generator.cabi` flag.