### PR TITLE
Chore: remove depreceated toolchain cicd dep

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-      - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - name: Check out Git repository
         uses: actions/checkout@v3 
         with: 


### PR DESCRIPTION
Removes the actions-rs/toolchain dep which throws many depreceated warnings.