### PR TITLE
Fix: forge command output leaking into testing

### DIFF
--- a/tests/feature-tests/tests/util/mod.rs
+++ b/tests/feature-tests/tests/util/mod.rs
@@ -71,9 +71,9 @@ pub async fn forge(modifier: u64) -> Result<()> {
         .arg("quiet")
         .arg("--generator.cabi_testing")
         .arg("true")
+        .stdout(std::process::Stdio::null())
         .spawn()?;
     let _status = forge_process.wait().await?;
-    // println!("forge command exited with: {}", _status);
     Ok(())
 }
 
@@ -94,9 +94,9 @@ pub async fn compile_generated_api(modifier: u64) -> Result<()> {
         .arg("--manifest-path")
         .arg(get_generated_api_path!(modifier) + "/Cargo.toml")
         .arg("--quiet")
+        .stdout(std::process::Stdio::null())
         .spawn()?;
     let _status = compile_proceess.wait().await?;
-    // println!("cargo command exited with: {}", _status);
     Ok(())
 }
 


### PR DESCRIPTION
Since forge now outputs `API generation completed` message even on quiet mode, with this PR we send all stdout of child processes to null.